### PR TITLE
Update nginx 301

### DIFF
--- a/ssl/default
+++ b/ssl/default
@@ -2,7 +2,7 @@ server {
         listen 80;
         listen [::]:80;
 
-        return 301 https://$server_name$request_uri;
+        return 301 https://$host$request_uri;
 }
 
 server {


### PR DESCRIPTION
TL & MG identified an issue where $server_name variable is null, correct variable in nginx is $host, updated variable so 301 redirect works (was redirecting to https:///)